### PR TITLE
GandiWidget now read cli config in section "widget"

### DIFF
--- a/gandi/widget/__main__.py
+++ b/gandi/widget/__main__.py
@@ -1,6 +1,22 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+"""
+GandiWidget will read in gandi.cli configuration
+~/.config/gandi/config.yaml
+
+You can add a section :
+widget:
+    sections:
+        - iaas
+        - paas
+        - domain
+    refresh: 60
+    status_refresh: 20
+
+"""
+
+
 from gandi.widget import GandiWidget
 from gi.repository import Gtk
 


### PR DESCRIPTION
This allow :
  * have less objects (domain, iaas, paas)
  * having different refresh and status_refresh