### PR TITLE
Add icon in installation process

### DIFF
--- a/packages/debian/control
+++ b/packages/debian/control
@@ -10,7 +10,6 @@ Build-Depends-Indep: python-setuptools,
  python-gi,
  python3-gi,
  dh-python,
- quilt,
  gir1.2-appindicator3 | gir1.2-appindicator3-0.1,
  python-appindicator,
  gir1.2-gtk-2.0,
@@ -18,7 +17,7 @@ Build-Depends-Indep: python-setuptools,
  gir1.2-glib-2.0,
  gir1.2-appindicator3-0.1,
  gir1.2-notify-0.7
-Standards-Version: 3.9.4
+Standards-Version: 3.9.6
 X-Python-Version: >= 2.6
 X-Python3-Version: >= 3.0
 
@@ -26,6 +25,7 @@ Package: python-gandi-widget
 Provides: gandi-widget, ${python:Provides}
 Architecture: all
 Depends: ${python:Depends},
+ ${misc:Depends},
  gir1.2-appindicator3 | gir1.2-appindicator3-0.1,
  python-appindicator,
  python-gi,
@@ -43,6 +43,7 @@ Package: python3-gandi-widget
 Provides: gandi-widget, ${python3:Provides}
 Architecture: all
 Depends: ${python3:Depends},
+ ${misc:Depends},
  gir1.2-appindicator3 | gir1.2-appindicator3-0.1,
  python-appindicator,
  python3-gi,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ extras_require = {
 
 tests_requires = requires + extras_require['test']
 
-
 setup(name=name,
       namespace_packages=['gandi'],
       version='0.3',
@@ -55,4 +54,7 @@ setup(name=name,
 [console_scripts]
 gwidget = gandi.widget.__main__:main
       """,
-      )
+      package_data = {
+          'gandi.widget': ['resources/*.png'],
+      }
+)


### PR DESCRIPTION
I notice the current Debian package does not ship the icon used by the python code. This pull request add the resources installation in the setuptools process and fix some small issues in Debian packaging.
